### PR TITLE
Alien pip3 support

### DIFF
--- a/bin/Alien
+++ b/bin/Alien
@@ -36,4 +36,9 @@ fi
 alientype="${prog%%:*}"
 alienpkg="${prog#*:}"
 shift 2
+if [[ ! -x /System/Index/bin/Alien-$alientype ]]
+then
+    echo "Error: $alientype is not a valid alientype"
+    exit 1
+fi
 exec Alien-$alientype $mode $alienpkg "$@"

--- a/bin/Alien
+++ b/bin/Alien
@@ -28,12 +28,12 @@ fi
 
 mode="$1"
 prog="$2"
-alientype="${prog%%:*}"
-alienpkg="${prog#*:}"
-if [[ -z "$alientype" || -z "$alienpkg" ]]
+if [[ ! $prog =~ ^.+:.+$ ]] 
 then
-   echo "Error: missing program name"
+   echo "Error: missing program name, format shoud be 'AlienType:program'"
    exit 1
 fi
+alientype="${prog%%:*}"
+alienpkg="${prog#*:}"
 shift 2
 exec Alien-$alientype $mode $alienpkg "$@"

--- a/bin/Alien-PIP
+++ b/bin/Alien-PIP
@@ -47,6 +47,7 @@ hasmanager() {
 }
 
 getversion() {
+
    local prog=$(echo "$1" | sed 's,\(.*\),\L\1,g')
    local proginfo=$(eval ${PIP} list 2>/dev/null | sed 's,\(.*\),\L\1,g' | grep "^${prog} ")
    if [ -z "$proginfo" ]
@@ -99,7 +100,8 @@ install() {
    then
       mkdir -p "$target" || { echo "Failed to create $target."; exit 1; }
    fi
-   eval ${PIP} install --upgrade --prefix=$target --src=$srcdir "$prog" $ver && \
+   [ ! -z $ver ] && prog_with_ver="$prog==$ver" || prog_with_ver="$prog"
+   eval ${PIP} install --upgrade --prefix=$target --src=$srcdir "$prog_with_ver" && \
       Symlink_Aliens "$goboExecutables" "$goboSystem"/Aliens/PIP/bin
 }
 

--- a/bin/Alien-PIP
+++ b/bin/Alien-PIP
@@ -50,7 +50,7 @@ def available_versions(prog):
       url = "https://pypi.python.org/pypi/%s/json" %prog
       data = load_json(urlopen(Request(url)))
       versions = list(data["releases"].keys())
-      versions.sort(key=StrictVersion)
+      versions.sort(key=StrictVersion, reverse=True)
       return versions
    except Exception as e:
       return []

--- a/bin/Alien-PIP
+++ b/bin/Alien-PIP
@@ -11,21 +11,28 @@
 Import Alien
 
 PYTHON=${ALIEN_PYTHON:-python2}
-case $PYTHON in
+case ${ALIEN_PYTHON:-python2} in
    "python2")
-       PIP=pip2
+       PYTHONVER=$(python2 --version 2>&1 | awk {'print $2'} | cut -b1-3)
+       ALIEN_PYTHON=python2
+       ALIEN_PIP=pip2
        ;;
    "python3")
-       PIP=pip3
+       PYTHONVER=$(python3 --version 2>&1 | awk {'print $2'} | cut -b1-3)
+       ALIEN_PYTHON=python3
+       ALIEN_PIP=pip3
        ;;
    *)
        exit 1
        ;;
 esac
 
+PYTHON="PYTHONPATH=$goboSystem/Aliens/PIP/lib/python${PYTHONVER}/site-packages $ALIEN_PYTHON"
+PIP="PYTHONPATH=$goboSystem/Aliens/PIP/lib/python${PYTHONVER}/site-packages $ALIEN_PIP"
+
 getversion() {
    local prog=$(echo "$1" | sed 's,\(.*\),\L\1,g')
-   local proginfo=$(${PIP} list 2>/dev/null | sed 's,\(.*\),\L\1,g' | grep "^${prog} ")
+   local proginfo=$(eval ${PIP} list 2>/dev/null | sed 's,\(.*\),\L\1,g' | grep "^${prog} ")
    if [ -z "$proginfo" ]
    then exit 1
    else echo "$proginfo" | cut -d\( -f2 | cut -d\) -f1
@@ -34,9 +41,9 @@ getversion() {
 
 getinstallversion() {
    prog="$1"
-   versions=($(${PYTHON} - << EOF
+   versions=($(eval ${PYTHON} - << EOF
 import json
-from distutils.version import StrictVersion
+from packaging.version import Version
 try:
    from urllib2 import urlopen, Request
    def load_json(res):
@@ -50,7 +57,7 @@ def available_versions(prog):
       url = "https://pypi.python.org/pypi/%s/json" %prog
       data = load_json(urlopen(Request(url)))
       versions = list(data["releases"].keys())
-      versions.sort(key=StrictVersion, reverse=True)
+      versions.sort(key=Version, reverse=True)
       return versions
    except Exception as e:
       return []
@@ -76,16 +83,15 @@ install() {
    then
       mkdir -p "$target" || { echo "Failed to create $target."; exit 1; }
    fi
-   ${PIP} install --upgrade --prefix=$target --src=$srcdir "$prog" $ver
-
-   Symlink_Aliens "$goboExecutables" "$goboSystem"/Aliens/PIP/bin
+   eval ${PIP} install --upgrade --prefix=$target --src=$srcdir "$prog" $ver && \
+      Symlink_Aliens "$goboExecutables" "$goboSystem"/Aliens/PIP/bin
 }
 
 remove() {
    local prog="$1"
    local ver="$2"
 
-   ${PIP} uninstall "$prog" $ver
+   eval ${PIP} uninstall "$prog" $ver
 
    Cleanup_Aliens
 }
@@ -99,6 +105,10 @@ case "$command" in
       [ $? -eq 0 ] && echo $ver || exit $?  # propagate the error
       ;;
    --getinstallversion)
+       [ -z $(getversion "packaging") ] && {
+         echo "pip module 'packaging' (see PEP440) not found, installing it first"
+         install packaging || exit 1
+      }
       echo $(getinstallversion "$2" "$3" "$4")
       ;;
    --greater-than)
@@ -114,7 +124,7 @@ case "$command" in
       In_Version_Range "$lower" "$ver" "$upper"
       ;;
    --have-manager)
-      which ${PIP} >/dev/null 2>&1 || exit 1
+      eval which ${PIP} >/dev/null 2>&1 || exit 1
       ;;
    --get-manager-rule)
       echo "PIP >= 7.0.0"

--- a/bin/Alien-PIP
+++ b/bin/Alien-PIP
@@ -25,10 +25,10 @@ esac
 
 getversion() {
    local prog=$(echo "$1" | sed 's,\(.*\),\L\1,g')
-   local proginfo=$(${PIP} list | sed 's,\(.*\),\L\1,g' | grep "^${prog} ")
+   local proginfo=$(${PIP} list 2>/dev/null | sed 's,\(.*\),\L\1,g' | grep "^${prog} ")
    if [ -z "$proginfo" ]
    then exit 1
-   else echo "$proginfo | cut -d\( -f2 | cut -d\) -f1"
+   else echo "$proginfo" | cut -d\( -f2 | cut -d\) -f1
    fi
 }
 
@@ -95,7 +95,8 @@ prog="$2"
 
 case "$command" in
    --getversion)
-      echo $(getversion "$2")
+      ver=$(getversion "$2")
+      [ $? -eq 0 ] && echo $ver || exit $?  # propagate the error
       ;;
    --getinstallversion)
       echo $(getinstallversion "$2" "$3" "$4")

--- a/bin/Alien-PIP
+++ b/bin/Alien-PIP
@@ -21,7 +21,7 @@ case ${ALIEN_PYTHON:-python2} in
    "python3")
        PYTHONVER=$(python3 --version 2>&1 | awk {'print $2'} | cut -b1-3)
        ALIEN_PYTHON=python3
-       ALIEN_PIP=pip3
+       ALIEN_PIP="python3 -m pip"
        MANAGER_RULE="Python >= 3.5.0"
        ;;
    *)
@@ -31,6 +31,20 @@ esac
 
 PYTHON="PYTHONPATH=$goboSystem/Aliens/PIP/lib/python${PYTHONVER}/site-packages $ALIEN_PYTHON"
 PIP="PYTHONPATH=$goboSystem/Aliens/PIP/lib/python${PYTHONVER}/site-packages $ALIEN_PIP"
+
+hasmanager() {
+    case ${ALIEN_PYTHON} in
+        "python2")
+            which $ALIEN_PIP > /dev/null 2>&1
+            ;;
+        "python3")
+            which $ALIEN_PYTHON > /dev/null 2>&1
+            ;;
+        *)
+            return 1
+    esac
+    return $?
+}
 
 getversion() {
    local prog=$(echo "$1" | sed 's,\(.*\),\L\1,g')
@@ -126,7 +140,7 @@ case "$command" in
       In_Version_Range "$lower" "$ver" "$upper"
       ;;
    --have-manager)
-      eval which ${PIP} >/dev/null 2>&1 || exit 1
+      hasmanager || exit 1
       ;;
    --get-manager-rule)
       echo $MANAGER_RULE

--- a/bin/Alien-PIP
+++ b/bin/Alien-PIP
@@ -77,7 +77,7 @@ install() {
       mkdir -p "$target" || { echo "Failed to create $target."; exit 1; }
    fi
    ${PIP} install --upgrade --prefix=$target --src=$srcdir "$prog" $ver
-   
+
    Symlink_Aliens "$goboExecutables" "$goboSystem"/Aliens/PIP/bin
 }
 
@@ -86,7 +86,7 @@ remove() {
    local ver="$2"
 
    ${PIP} uninstall "$prog" $ver
-   
+
    Cleanup_Aliens
 }
 
@@ -110,7 +110,7 @@ case "$command" in
       lower="$3"
       upper="$4"
       ver=$(getversion "$2")
-	  In_Version_Range "$lower" "$ver" "$upper"
+      In_Version_Range "$lower" "$ver" "$upper"
       ;;
    --have-manager)
       which ${PIP} >/dev/null 2>&1 || exit 1

--- a/bin/Alien-PIP
+++ b/bin/Alien-PIP
@@ -10,9 +10,22 @@
 . ScriptFunctions
 Import Alien
 
+PYTHON=${ALIEN_PYTHON:-python2}
+case $PYTHON in
+   "python2")
+       PIP=pip2
+       ;;
+   "python3")
+       PIP=pip3
+       ;;
+   *)
+       exit 1
+       ;;
+esac
+
 getversion() {
    local prog=$(echo "$1" | sed 's,\(.*\),\L\1,g')
-   local proginfo=$(pip list | sed 's,\(.*\),\L\1,g' | grep "^${prog} ")
+   local proginfo=$(${PIP} list | sed 's,\(.*\),\L\1,g' | grep "^${prog} ")
    if [ -z "$proginfo" ]
    then exit 1
    else echo "$proginfo | cut -d\( -f2 | cut -d\) -f1"
@@ -21,19 +34,27 @@ getversion() {
 
 getinstallversion() {
    prog="$1"
-   versions=($(python - << EOF 
-import json, urllib2
+   versions=($(${PYTHON} - << EOF
+import json
 from distutils.version import StrictVersion
+try:
+   from urllib2 import urlopen, Request
+   def load_json(res):
+      return json.load(res)
+except ModuleNotFoundError:
+   from urllib.request import urlopen, Request
+   def load_json(res):
+      return json.loads('\n'.join([l.decode() for l in res.readlines()]))
 def available_versions(prog):
    try:
-     url = "https://pypi.python.org/pypi/%s/json" %prog
-     data = json.load(urllib2.urlopen(urllib2.Request(url)))
-     versions = data["releases"].keys()
-     versions.sort(key=StrictVersion)
-     return versions
-   except:
-     return ''
-print "\n".join(available_versions("$prog"))
+      url = "https://pypi.python.org/pypi/%s/json" %prog
+      data = load_json(urlopen(Request(url)))
+      versions = list(data["releases"].keys())
+      versions.sort(key=StrictVersion)
+      return versions
+   except Exception as e:
+      return []
+print("\n".join(available_versions("$prog")))
 EOF
    ))
    for V in ${versions[@]}
@@ -55,7 +76,7 @@ install() {
    then
       mkdir -p "$target" || { echo "Failed to create $target."; exit 1; }
    fi
-   pip install --upgrade --prefix=$target --src=$srcdir "$prog" $ver
+   ${PIP} install --upgrade --prefix=$target --src=$srcdir "$prog" $ver
    
    Symlink_Aliens "$goboExecutables" "$goboSystem"/Aliens/PIP/bin
 }
@@ -64,7 +85,7 @@ remove() {
    local prog="$1"
    local ver="$2"
 
-   pip uninstall "$prog" $ver
+   ${PIP} uninstall "$prog" $ver
    
    Cleanup_Aliens
 }
@@ -92,7 +113,7 @@ case "$command" in
 	  In_Version_Range "$lower" "$ver" "$upper"
       ;;
    --have-manager)
-      which pip >/dev/null 2>&1 || exit 1
+      which ${PIP} >/dev/null 2>&1 || exit 1
       ;;
    --get-manager-rule)
       echo "PIP >= 7.0.0"

--- a/bin/Alien-PIP
+++ b/bin/Alien-PIP
@@ -16,11 +16,13 @@ case ${ALIEN_PYTHON:-python2} in
        PYTHONVER=$(python2 --version 2>&1 | awk {'print $2'} | cut -b1-3)
        ALIEN_PYTHON=python2
        ALIEN_PIP=pip2
+       MANAGER_RULE="PIP >= 7.0.0"
        ;;
    "python3")
        PYTHONVER=$(python3 --version 2>&1 | awk {'print $2'} | cut -b1-3)
        ALIEN_PYTHON=python3
        ALIEN_PIP=pip3
+       MANAGER_RULE="Python >= 3.5.0"
        ;;
    *)
        exit 1
@@ -127,7 +129,7 @@ case "$command" in
       eval which ${PIP} >/dev/null 2>&1 || exit 1
       ;;
    --get-manager-rule)
-      echo "PIP >= 7.0.0"
+      echo $MANAGER_RULE
       ;;
    --install)
       install "$2" "$3"

--- a/bin/Alien-PIP3
+++ b/bin/Alien-PIP3
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# Shell script implementing the Aliens interface for PIP3.
+# Packages are installed onto /System/Aliens/PIP. The Python module search path
+# must include that directory, either through PYTHONPATH or through a .pth file.
+#
+# Copyright 2017 Aitor P. Iturri.
+# Released under the GNU GPL 2 or later.
+
+exec env ALIEN_PYTHON=python3 Alien-PIP $@


### PR DESCRIPTION
This PR adds a new namespace PIP3.
With this PR we should be able to specify pip3 dependencies like this: `PIP3:package`.
It also makes `getinstallversion` to return the latest version, it was returning the oldest version before.