### PR TITLE
Fix blank lines stopping file read

### DIFF
--- a/src/FindDependencies.c
+++ b/src/FindDependencies.c
@@ -579,7 +579,7 @@ static char *ReadLine(char *buf, int size, FILE *fp)
 		/* lookahead */
 		next = fgetc(fp);
 		ungetc(next, fp);
-		if (next != EOF && !isprint(next))
+		if (next != EOF && !isprint(next) && !isspace(next))
 			/* this is likely an ELF file; stop parsing it */
 			return NULL;
 	}


### PR DESCRIPTION
If a blank line was encountered in the Dependency file, the file would stop being read on the spot and the the previous line's dependency wouldn't be included. This adds a check for whitespace before assuming the file is an ELF

Example dependency file:
```
Dep1
Dep2
Dep3

Dep4
```

was only including `Dep1` and `Dep2` before assuming the file was ELF and stopping the read.