### PR TITLE
`ListProgramFiles`: Do not list links with the `--files` option

### DIFF
--- a/bin/ListProgramFiles
+++ b/bin/ListProgramFiles
@@ -11,7 +11,7 @@ scriptDescription="List files from a program in a 'clean' way, skipping some fil
 scriptCredits="Copyright (C) 2006. Released under the GNU GPL."
 helpOnNoArguments=yes
 scriptUsage="<program> [<version>] | <version_directory>"
-Add_Option_Boolean "f" "files" "List files (equivalent to -xtype f in 'find')"
+Add_Option_Boolean "f" "files" "List files (equivalent to -type f in 'find')"
 Add_Option_Boolean "l" "links" "List links (equivalent to -type l in 'find')"
 Add_Option_Boolean "R" "no-resources" "Do not list files in Resources directory"
 Add_Option_Boolean "p" "path" "Return full path, including the programs directory"
@@ -42,7 +42,7 @@ unset type
 if Boolean "files" && Boolean "links"
 then type="( -type f -or -type l )"
 elif Boolean "files"
-then type="-xtype f"
+then type="-type f"
 elif Boolean "links"
 then type="-type l"
 fi


### PR DESCRIPTION
Calling `ListProgramFiles --files` will now omit links in its output. If we desire to include links we can call `ListProgramFiles --files --links` instead. I believe this adds more flexibity to the tool.

@hishamhm looks like you are the original author of `ListProgramFiles`! Would you be in favor of this change?

The benefit is, that we can now list program files _excluding_ links - and that was not possible before. Moreover no functionality is lost with this change.

I came up with this change because I experimented with some bash scripting on GoboLinux and wanted to list the program files without internal links. Even though (as of now) I do not need this functionality anymore, I think this could still be useful! :)

_Small disclaimer:_ I have searched through the repos to make sure `ListProgramFiles --files` isn't being used in a gobolinux script, as this could affect the results. I haven't found any, so this should be safe to merge. For reference: https://github.com/search?q=org%3Agobolinux%20ListProgramFiles&type=code