### PR TITLE
CompatibilityList Runner Fix

### DIFF
--- a/src/FindDependencies.c
+++ b/src/FindDependencies.c
@@ -747,7 +747,7 @@ static void PrintRestrictions(struct parse_data *data, struct search_options *op
 
 static bool ParseName(struct parse_data *data, struct search_options *options)
 {
-	data->depname = strtok_r(data->workbuf, " \t><=!", &data->saveptr);
+	data->depname = strdup(strtok_r(data->workbuf, " \t><=!", &data->saveptr));
 	if (options->dependency && strcmp(data->depname, options->dependency))
 		return false;
 	return data->depname ? true : false;


### PR DESCRIPTION
My commit dates are all out of wack, sorry! The first was done on windows (proper date) the other 2 on my old Gobo install for testing, looks like the install's time is off :<

fixing https://github.com/gobolinux/Scripts/issues/48#issuecomment-3024259775

Notes: It isn't efficient, it rereads the CompatibilityList for every dependency ie zero caching there. But it should work. It may be advisable for performance's sake to cache CompatibilityList into a hashmap and lookup from there, however I'm not familiar enough with the codebase at the moment, so for the time being this should suffice.

proper commit order was:
51f1181d46cd5f928caa5c214aab3e1d04376240
8365dc84718e63c03177850fc4042535149a521a
c9e9113fe557f8bb084cfbd27ed2a9fb8d59a194