### PR TITLE
Alien-PIP getinstallversion() reports bad version

### DIFF
--- a/bin/Alien-PIP
+++ b/bin/Alien-PIP
@@ -27,13 +27,13 @@ try:
    from urllib2 import urlopen, Request
 except ImportError:
    from urllib.request import urlopen, Request
-from distutils.version import StrictVersion
+from pkg_resources import parse_version 
 def available_versions(prog):
    try:
      url = "https://pypi.python.org/pypi/%s/json" %prog
      data = json.load(urlopen(Request(url)))
-     versions = data["releases"].keys()
-     versions.sort(key=StrictVersion)
+     versions = list(data["releases"].keys())
+     versions.sort(key=parse_version)
      return versions
    except:
      return ''

--- a/lib/python3.8/site-packages/Alien.py
+++ b/lib/python3.8/site-packages/Alien.py
@@ -44,7 +44,7 @@ def getinstallversion(rule):
     alientype, alienpkg, lowerbound, upperbound = parse_rule(rule)
     p = subprocess.Popen(['Alien-' + alientype, '--getinstallversion',
                           alienpkg, lowerbound, upperbound], stdout=subprocess.PIPE)
-    return p.stdout.read().strip()
+    return p.stdout.read().decode('utf-8').strip()
 
 
 def split(program):


### PR DESCRIPTION
Here we replace `distutils` with `pkg_resources` as the previous is:
- painfully obsolete,
- removed from python 3.12 onward,
- panics when faced with modern pip package versioning, like `0.37.0rc1`.

I opted to use `pkg_resources` and not `packaging` because it is pre-installed on the base gobo system.

The `available_versions()` try-except would always fail as it was calling `sort()` on a `dict_keys` object, with a cast to `list` we can sort it as intended.

In `Alien.py` we call `Alien-NNN` and read the results from `stdout`, however we read it as a byte-array and not as a string, now we decode the byte-array as a "UTF-8" string so that we can properly compare it against the returned list of versions. This may cause issues with other locales, I'm unaware of how to detect the encoding used. I'm open to suggestions.